### PR TITLE
Fixed netlist warning

### DIFF
--- a/xschem/EF_AMUX21x.sch
+++ b/xschem/EF_AMUX21x.sch
@@ -135,3 +135,4 @@ C {sky130_stdcells/inv_2.sym} 660 -120 0 0 {name=x10 VGND=dvss VNB=dvss VPB=vdd3
 C {sky130_stdcells/nor2_1.sym} 310 -200 0 0 {name=x1 VGND=dvss VNB=dvss VPB=vdd3p3 VPWR=vdd3p3 prefix=sky130_fd_sc_hvl__ }
 C {sky130_stdcells/nor2_1.sym} 230 -70 0 0 {name=x3 VGND=dvss VNB=dvss VPB=vdd3p3 VPWR=vdd3p3 prefix=sky130_fd_sc_hvl__ }
 C {sky130_stdcells/decap_8.sym} 190 40 0 0 {name=x4[3:0] VGND=dvss VNB=dvss VPB=vdd3p3 VPWR=vdd3p3 prefix=sky130_fd_sc_hvl__ }
+C {noconn.sym} -200 -160 0 1 {name=l1}

--- a/xschem/cdac_lvlshift_array.sch
+++ b/xschem/cdac_lvlshift_array.sch
@@ -185,3 +185,6 @@ C {lsbuflv2hv_1.sym} 440 -100 0 0 {name=x28 LVPWR=vdd1p8 VGND=vss VNB=vss VPB=vd
 C {sky130_stdcells/decap_4.sym} 890 -80 0 0 {name=x29[14:0] VGND=vss VNB=vss VPB=vdd3p3 VPWR=vdd3p3 prefix=sky130_fd_sc_hvl__ }
 C {sky130_stdcells/inv_2.sym} 650 -10 0 0 {name=x29 VGND=vss VNB=vss VPB=vdd3p3 VPWR=vdd3p3 prefix=sky130_fd_sc_hvl__ }
 C {devices/opin.sym} 730 -10 0 0 {name=p32 lab=holdb_3p3}
+C {noconn.sym} -200 -220 0 1 {name=l1}
+C {noconn.sym} -200 -200 0 1 {name=l2}
+C {noconn.sym} -200 -180 0 1 {name=l3}


### PR DESCRIPTION
A warning is generated when netlisting power ports that only connect to digital symbols. The digital symbols do not contain power pins because power connections are added as properties. This change adds a noconn device to power pins with no detected connections. There might be a more elegant solution.

These are the warnings that are resolved.
```
-----------.../cheetah_v4_analog/dependencies/sky130_ef_ip__cdac3v_12bit/xschem/cdac_lvlshift_array.sch
Warning: open net: vss
Warning: open net: vdd1p8
Warning: open net: vdd3p3
-----------.../cheetah_v4_analog/dependencies/sky130_ef_ip__cdac3v_12bit/xschem/EF_AMUX21x.sch
Warning: open net: dvss
```